### PR TITLE
[stduart] Fix MSVC build

### DIFF
--- a/extra/samples/stduart/main.cpp
+++ b/extra/samples/stduart/main.cpp
@@ -28,6 +28,7 @@
 #include <span>
 #include <string_view>
 #include <thread>
+#include <utility>
 #include <SMCE/Board.hpp>
 #include <SMCE/BoardConf.hpp>
 #include <SMCE/BoardView.hpp>
@@ -79,10 +80,12 @@ int main(int argc, char** argv) {
     smce::Board board; // Create the virtual Arduino board
     board.attach_sketch(sketch);
     // clang-format off
-    board.configure({
+    smce::BoardConfig board_conf{
         .uart_channels = { {} },
         .sd_cards = { smce::BoardConfig::SecureDigitalStorage{ .root_dir = "." } }
-    });
+    };
+
+    board.configure(std::move(board_conf));
     // clang-format on
 
     // Power-on the board

--- a/extra/samples/stduart/main.cpp
+++ b/extra/samples/stduart/main.cpp
@@ -20,6 +20,7 @@
 #    error "SMCE_RESOURCES_DIR is not set"
 #endif
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -121,7 +122,7 @@ int main(int argc, char** argv) {
         }
         if (std::cin.eof())
             break;
-        uart0.rx().write((const char[]){'\n'});
+        uart0.rx().write({{'\n'}});
     }
 
     run = false;


### PR DESCRIPTION
Fixes "error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax" in MSVC by moving out initializer values to variables.
BoardConfig was also separated, as this created a "C1001: internal compiler error".