### PR TITLE
Added seperate method for CMake check in toolchain

### DIFF
--- a/include/SMCE/Toolchain.hpp
+++ b/include/SMCE/Toolchain.hpp
@@ -90,6 +90,7 @@ class SMCE_API Toolchain {
      **/
     [[nodiscard]] std::error_code check_suitable_environment() noexcept;
 
+    [[nodiscard]] std::error_code check_cmake_availability() noexcept;
     /**
      * Compile a sketch
      **/


### PR DESCRIPTION
This adds an extra method to Toolchain that checks for CMake.

The "Install cmake on startup" pull-request to smce-gd relies on this to work properly.

Squashed a bunch of commits and removed a bunch of unrelated stuff just before making the pull-request. Is a hassle to test so I didn't bother. Should still work but if it doesn't you know why. 