### PR TITLE
Return WL_CONNECTED from WiFiClass stubs

### DIFF
--- a/include/Ardrivo/WiFi.h
+++ b/include/Ardrivo/WiFi.h
@@ -57,14 +57,14 @@ enum wl_enc_type {
 };
 
 struct WiFiClass {
-    int begin() { return 0; }
-    int begin([[maybe_unused]] const char* ssid) { return WL_NO_SHIELD; }
-    int begin([[maybe_unused]] const char* ssid, [[maybe_unused]] const char* pass) { return WL_NO_SHIELD; }
+    int begin() { return WL_CONNECTED; }
+    int begin([[maybe_unused]] const char* ssid) { return WL_CONNECTED; }
+    int begin([[maybe_unused]] const char* ssid, [[maybe_unused]] const char* pass) { return WL_CONNECTED; }
     int begin([[maybe_unused]] const char* ssid, [[maybe_unused]] std::uint8_t key_idx,
               [[maybe_unused]] const char* key) {
-        return WL_NO_SHIELD;
+        return WL_CONNECTED;
     }
-    int disconnect() { return WL_NO_SHIELD; }
+    int disconnect() { return WL_DISCONNECTED; }
     void config([[maybe_unused]] IPAddress local_ip) {}
     void config([[maybe_unused]] IPAddress local_ip, [[maybe_unused]] IPAddress dns_server) {}
     void config([[maybe_unused]] IPAddress local_ip, [[maybe_unused]] IPAddress dns_server,
@@ -83,7 +83,7 @@ struct WiFiClass {
     std::int8_t scanNetworks() { return 0; }
     /*[[nodiscard]]*/ static std::uint8_t getSocket() { return 0; }
     std::uint8_t* macAddress(std::uint8_t* mac) const;
-    /*[[nodiscard]]*/ int status() const { return WL_NO_SHIELD; }
+    /*[[nodiscard]]*/ int status() const { return WL_CONNECTED; }
 
     /*[[nodiscard]]*/ IPAddress localIP() { return {}; }
     /*[[nodiscard]]*/ IPAddress subnetMask() { return {}; }


### PR DESCRIPTION
Since these stubs are there for allowing the users to have the same code running for both the emulator as well as the real Smartcar, let's always return a successful code back, to eliminate the need for handling a value which is -practically- only returned in the emulator.